### PR TITLE
Fixed modman paths for Composer

### DIFF
--- a/modman
+++ b/modman
@@ -1,2 +1,2 @@
-app/etc/modules/Aoe_CacheCleaner.xml
-app/code/local/Aoe/CacheCleaner
+app/code/local/Aoe/CacheCleaner app/code/local/Aoe/CacheCleaner
+app/etc/modules/Aoe_CacheCleaner.xml app/etc/modules/Aoe_CacheCleaner.xml


### PR DESCRIPTION
Fixes Composer throwing exception:

“[ErrorException]
  Invalid row on line 1 has 1 parts, expected 2”