### PR TITLE
removed duplicate xml tags

### DIFF
--- a/app/code/community/Aoe/CacheCleaner/etc/config.xml
+++ b/app/code/community/Aoe/CacheCleaner/etc/config.xml
@@ -3,8 +3,6 @@
 
     <modules>
         <Aoe_CacheCleaner>
-            <active>true</active>
-            <codePool>local</codePool>
             <version>0.1.1</version>
         </Aoe_CacheCleaner>
     </modules>


### PR DESCRIPTION
- xml tags <active> and <codePool> already specified in etc/modules/Aoe_CacheCleaner.xml
- here, <codePool> incorrectly specified as "local", causing module not to appear in Magento > System configuration panel