### PR TITLE
Prevent Warnings

### DIFF
--- a/app/code/community/Aoe/CacheCleaner/Model/Cleaner.php
+++ b/app/code/community/Aoe/CacheCleaner/Model/Cleaner.php
@@ -23,7 +23,7 @@ class Aoe_CacheCleaner_Model_Cleaner
         $duration = time() - $startTime;
         Mage::log('[CACHECLEANER] Cleaning cache (duration: ' . $duration . ')');
 
-        if (class_exists('Enterprise_PageCache_Model_Cache')) {
+        if (Mage::helper('core')->isModuleEnabled('Enterprise_PageCache')) {
             $startTime = time();
             Enterprise_PageCache_Model_Cache::getCacheInstance()->getFrontend()->getBackend()->clean(Zend_Cache::CLEANING_MODE_OLD);
             $duration = time() - $startTime;


### PR DESCRIPTION
I do not fully understand why, but the check `class_exists('Enterprise_PageCache_Model_Cache')` gives a warning on CE systems in the system.log:

```
2015-08-18T07:21:03+00:00 ERR (3): Warning: include(Enterprise/PageCache/Model/Cache.php): failed to open stream: No such file or directory  in /html/shop/lib/Varien/Autoload.php on line 94
2015-08-18T07:21:03+00:00 ERR (3): Warning: include(): Failed opening 'Enterprise/PageCache/Model/Cache.php' for inclusion (include_path='/html/shop/app/code/local:/html/shop/app/code/community:/html/shop/app/code/core:/html/shop/lib:.:/usr/local/php/lib/php:/usr/local/php/lib/php/PEAR')  in /html/shop/lib/Varien/Autoload.php on line 94
```

Checking if the `Enterprise_PageCache` module is enabled should be fine, too and should not come up with a warning.
